### PR TITLE
Fix path issue on Linux/macOS

### DIFF
--- a/api/umodextractor.js
+++ b/api/umodextractor.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 
 
 
@@ -120,26 +121,21 @@ class UModExtractor{
 
     createFiles(){
 
-
-        let f = 0;
-
-        let currentData = 0;
-
-        const dirReg = /^(.+)(\/|\\).+\..+$/;
-        let dirResult = 0;
-
         try{
 
             for(let i = 0; i < this.files.length; i++){
 
-                f = this.files[i];
+                const f = this.files[i];
 
-                dirResult = dirReg.exec(f.src);
+                // Convert src to format used by host system
+                //const src = f.src.split(/[/\\]/).join(path.sep);
+                const src = path.join(...f.src.split(/[/\\]/));
+                const dir = path.dirname(src);
 
-                fs.mkdirSync(dirResult[1], {recursive: true});
-                currentData = this.buffer.slice(f.offset + this.startIndex, f.offset + f.size + this.startIndex);
-                console.log(`[Note]: Creating file ${dirResult[1]}/${f.src}`);
-                fs.writeFileSync(f.src, currentData);
+                fs.mkdirSync(dir, {recursive: true});
+                const currentData = this.buffer.slice(f.offset + this.startIndex, f.offset + f.size + this.startIndex);
+                console.log(`[Note]: Creating file ${src}`);
+                fs.writeFileSync(src, currentData);
 
             }
 


### PR DESCRIPTION
The code was using `\` path separator on Linux, because that was the separator used in the umod.

As a result, it was creating a file called `Textures\richrig.utx` instead of a file `richrig.utx` in the directory `Textures`.

This implementation should be platform-agnostic.

----

There was also an issue with a umod that contained a file in the root folder: `dirReg` was getting no matches, so `dirResult` was `null`, so `dirResult[1]` produced the error: `TypeError: Cannot read property '1' of null`

Using node's `path` module to extract the directory avoids that issue.

----

I also brought the regexp and declarations locally, because that's the common JavaScript style.

Unlike `var` which get hoisted to function scope, `const` and `let` scope to the block.